### PR TITLE
Includenamespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ default `empty`
           Nested fields can be specified dot-delimited e.g. fieldname 4 within fieldname 3 within fieldname 2:
           "value.converter.json.<schema name 1>.<fieldname 2>.<fieldname 3>.<fieldname 4>": "true"
 
+### value.converter.includenamespace
+default `false`
+
+    Set to true if the produced JSON should include AVRO namespaces.
+
 ### extracting schema fields
 default `empty`
 <p>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <groupId>no.norsktipping</groupId>
     <artifactId>kafka-connect-jdbc-json-connector</artifactId>
     <packaging>jar</packaging>
-    <version>10.2.1</version>
+    <version>10.2.2</version>
     <name>kafka-connect-jdbc-json-connector</name>
     <organization>
         <name>Norsk Tipping AS</name>
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>no.norsktipping</groupId>
             <artifactId>kafka-connect-converter-json</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
@@ -127,8 +127,9 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
             "\"c7\" TIMESTAMP DEFAULT '2001-03-15 00:00:00.000'," + System.lineSeparator() +
             "\"c8\" NUMBER(*,4) NULL," + System.lineSeparator() +
             "\"c9\" NUMBER(1,0) DEFAULT 1," + System.lineSeparator() +
-            "\"event\" BLOB NOT NULL) NOCACHE NOLOGGING " + System.lineSeparator() +
-            " LOB (\"c3\",\"c4\",\"event\")" + System.lineSeparator() +
+            "\"event\" BLOB NOT NULL,"  + System.lineSeparator() +
+            "CONSTRAINT myTable_ensure_json CHECK (\"EVENT\" IS JSON)) NOCACHE NOLOGGING " + System.lineSeparator() +
+    " LOB (\"c3\",\"c4\",\"event\")" + System.lineSeparator() +
             " STORE AS SECUREFILE (COMPRESS HIGH ENABLE STORAGE IN ROW NOCACHE NOLOGGING) " + System.lineSeparator() +
             "" + System.lineSeparator() +
             "PARTITION BY HASH (\"C1\")(" + System.lineSeparator() +


### PR DESCRIPTION
## Problem
The JSON output do not include the AVRO namespace which tells what action has been taken on events.

## Solution
Include kafka-connect-converter-json version 1.0.1 that supports includenamespace.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
